### PR TITLE
Use an indexers index file to consolidate requires

### DIFF
--- a/bin/indexer
+++ b/bin/indexer
@@ -11,15 +11,8 @@ const { green } = require('chalk');
 const settings = require('../config');
 const db = require('../lib/db');
 const { createESClient } = require('../lib/elasticsearch');
-const projectsIndexer = require('../lib/indexers/projects');
-const profilesIndexer = require('../lib/indexers/profiles');
-const establishmentsIndexer = require('../lib/indexers/establishments');
 
-const indexers = {
-  projects: projectsIndexer,
-  profiles: profilesIndexer,
-  establishments: establishmentsIndexer
-};
+const indexers = require('../lib/indexers');
 
 const start = process.hrtime();
 const args = minimist(process.argv.slice(2));

--- a/lib/indexers/index.js
+++ b/lib/indexers/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  establishments: require('./establishments'),
+  projects: require('./projects'),
+  profiles: require('./profiles')
+};


### PR DESCRIPTION
This is cleaner than requiring the files individually and then consolidating into an object.