### PR TITLE
Don't index titles

### DIFF
--- a/lib/indexers/profiles.js
+++ b/lib/indexers/profiles.js
@@ -9,7 +9,7 @@ const indexProfile = (esClient, profile) => {
     id: profile.id,
     body: {
       ...pick(profile, columnsToIndex),
-      name: `${profile.title} ${profile.firstName} ${profile.lastName}`,
+      name: `${profile.firstName} ${profile.lastName}`,
       establishments: profile.establishments.map(e => pick(e, 'id', 'name'))
     }
   });


### PR DESCRIPTION
New profiles in prod don't have any title property so indexing them will result in a lot of "undefined"