### PR TITLE
Return results in expected format

### DIFF
--- a/bin/indexer
+++ b/bin/indexer
@@ -16,7 +16,7 @@ const indexers = require('../lib/indexers');
 
 const start = process.hrtime();
 const args = minimist(process.argv.slice(2));
-const model = args._[0];
+const model = args._[0] || 'all';
 
 console.log(`Attempting to index "${green(model)}"\n`);
 

--- a/bin/search
+++ b/bin/search
@@ -15,7 +15,7 @@ const search = require('../lib/search');
 const start = process.hrtime();
 const args = minimist(process.argv.slice(2));
 const term = args._.join(' ');
-const index = args.i;
+const index = args.index || args.i;
 
 if (!term) {
   console.error('Search term must be defined');

--- a/config.js
+++ b/config.js
@@ -24,13 +24,12 @@ module.exports = {
     }
   },
 
-  // auth: {
-  //   realm: process.env.KEYCLOAK_REALM,
-  //   url: process.env.KEYCLOAK_URL,
-  //   client: process.env.KEYCLOAK_CLIENT,
-  //   secret: process.env.KEYCLOAK_SECRET,
-  //   permissions: process.env.PERMISSIONS_SERVICE
-  // },
+  auth: {
+    realm: process.env.KEYCLOAK_REALM,
+    url: process.env.KEYCLOAK_URL,
+    client: process.env.KEYCLOAK_CLIENT,
+    secret: process.env.KEYCLOAK_SECRET
+  },
 
   db: {
     database: process.env.DATABASE_NAME || 'asl',

--- a/lib/indexers/establishments.js
+++ b/lib/indexers/establishments.js
@@ -1,14 +1,15 @@
 const { pick } = require('lodash');
 
 const indexName = 'establishments';
-const columnsToIndex = ['id', 'name', 'licenceNumber'];
+const columnsToIndex = ['id', 'name', 'licenceNumber', 'status'];
 
 const indexEstablishment = (esClient, establishment) => {
   return esClient.index({
     index: indexName,
     id: establishment.id,
     body: {
-      ...pick(establishment, columnsToIndex)
+      ...pick(establishment, columnsToIndex),
+      asru: establishment.asru.map(p => pick(p, 'id', 'firstName', 'lastName', 'asruInspector', 'asruLicensing'))
     }
   });
 };
@@ -19,7 +20,8 @@ module.exports = (schema, esClient) => {
   return Promise.resolve()
     .then(() => {
       return Establishment.query()
-        .select(columnsToIndex);
+        .select(columnsToIndex)
+        .withGraphFetched('[asru]');
     })
     .then(establishments => {
       console.log(`Indexing ${establishments.length} establishments`);

--- a/lib/router/search.js
+++ b/lib/router/search.js
@@ -25,7 +25,7 @@ module.exports = (settings) => {
   });
 
   app.get('/:index', (req, res, next) => {
-    const term = req.query.q;
+    const term = req.query.q || req.query.search;
     const index = req.params.index;
 
     if (!term) {
@@ -35,7 +35,7 @@ module.exports = (settings) => {
     return Promise.resolve()
       .then(() => req.search(term, index))
       .then(response => {
-        res.response = response.body.hits.hits;
+        res.response = response.body.hits.hits.map(r => r._source);
         res.meta = {
           count: response.body.hits.total.value,
           maxScore: response.body.hits.max_score

--- a/lib/search.js
+++ b/lib/search.js
@@ -17,11 +17,11 @@ module.exports = (client) => (term, index = 'projects') => {
 
   switch (index) {
     case 'projects':
-      params.body.query.match = { content: { query: term } };
+      params.body.query.match = { content: { query: term, fuzziness: 'AUTO' } };
       break;
 
     default:
-      params.body.query.match = { name: { query: term } };
+      params.body.query.match = { name: { query: term, fuzziness: 'AUTO' } };
       break;
   }
 


### PR DESCRIPTION
Includes all the fields which the search pages expect to receive on search results.

We may want to optimise this in future because it stores some redundant data, but now it allows direct proxying of requests through the API to the search service.