### PR TITLE
Add `--reset` flag to delete old indexes

### DIFF
--- a/bin/indexer
+++ b/bin/indexer
@@ -18,20 +18,36 @@ const start = process.hrtime();
 const args = minimist(process.argv.slice(2));
 const model = args._[0] || 'all';
 
-console.log(`Attempting to index "${green(model)}"\n`);
 
 Promise.resolve()
   .then(() => createESClient(settings.es))
   .then(esClient => {
+    const index = key => {
+      console.log(`Indexing ${green(key)}`);
+      const indexer = indexers[key];
+      if (!indexer) {
+        throw new Error(`No indexer available for ${green(model)}.`);
+      }
+      return Promise.resolve()
+        .then(() => {
+          if (args.reset) {
+            console.log(`Resetting index ${green(key)}`);
+            return esClient.indices.delete({ index: key });
+          }
+        })
+        .then(() => {
+          return indexer(db, esClient);
+        })
+        .then(() => {
+          console.log(`Completed index ${green(key)}`);
+          console.log();
+        });
+    };
+
     if (model === 'all') {
-      return Promise.all(map(indexers, indexer => indexer(db, esClient)));
+      return Object.keys(indexers).reduce((p, key) => p.then(() => index(key)), Promise.resolve());
     }
-
-    if (indexers[model]) {
-      return indexers[model](db, esClient);
-    }
-
-    throw new Error(`No indexer available for ${green(model)}. If you want to index everything, pass 'all' as the first argument`);
+    return index(model);
   })
 
   .then(() => {


### PR DESCRIPTION
Seeds running on dev mean the ids for all dev data are periodically reset. This means that the old indexes need to be deleted when running on dev.

Add a flag that deletes the old index before creating a new one so that old dev records are purged from the index.