### PR TITLE
Add status filters and total counts

### DIFF
--- a/lib/indexers/projects.js
+++ b/lib/indexers/projects.js
@@ -45,6 +45,13 @@ const indexProject = (esClient, project, ProjectVersion) => {
     .then(version => {
       const { data } = version || { data: {} };
       const content = traverse(data);
+      const fields = [
+        project.licenceHolder.firstName,
+        project.licenceHolder.lastName,
+        project.establishment.name,
+        project.title,
+        project.licenceNumber
+      ];
       return esClient.index({
         index: indexName,
         id: project.id,
@@ -52,7 +59,8 @@ const indexProject = (esClient, project, ProjectVersion) => {
           ...pick(project, columnsToIndex),
           licenceHolder: pick(project.licenceHolder, 'id', 'firstName', 'lastName'),
           establishment: pick(project.establishment, 'id', 'name'),
-          content: [project.licenceHolder.firstName, project.licenceHolder.lastName, content].join(' ')
+          search: fields.join(' '),
+          content: [ ...fields, content ].join(' ')
         }
       });
     });

--- a/lib/router/search.js
+++ b/lib/router/search.js
@@ -52,5 +52,17 @@ module.exports = (settings) => {
       });
   });
 
+  app.get('/:index', (req, res, next) => {
+    switch (req.params.index) {
+      case 'establishments':
+        res.meta.filters = ['active', 'inactive', 'revoked'];
+        break;
+      case 'projects':
+        res.meta.filters = ['active', 'inactive', 'expired', 'revoked', 'transferred'];
+        break;
+    }
+    next();
+  });
+
   return app;
 };

--- a/lib/router/search.js
+++ b/lib/router/search.js
@@ -33,10 +33,11 @@ module.exports = (settings) => {
     }
 
     return Promise.resolve()
-      .then(() => req.search(term, index))
+      .then(() => req.search(term, index, req.query.filters))
       .then(response => {
         res.response = response.body.hits.hits.map(r => r._source);
         res.meta = {
+          total: response.body.count,
           count: response.body.hits.total.value,
           maxScore: response.body.hits.max_score
         };

--- a/lib/router/search.js
+++ b/lib/router/search.js
@@ -28,10 +28,6 @@ module.exports = (settings) => {
     const term = req.query.q || req.query.search;
     const index = req.params.index;
 
-    if (!term) {
-      throw new BadRequestError('Search term must be defined');
-    }
-
     return Promise.resolve()
       .then(() => req.search(term, index, req.query.filters))
       .then(response => {

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,6 +1,6 @@
 const indexes = ['projects', 'profiles', 'establishments'];
 
-module.exports = (client) => (term, index = 'projects') => {
+module.exports = (client) => (term, index = 'projects', filters = {}) => {
   if (!indexes.includes(index)) {
     throw new Error(`There is no available search index called ${index}`);
   }
@@ -10,23 +10,36 @@ module.exports = (client) => (term, index = 'projects') => {
     size: 50,
     body: {
       query: {
-        match: {}
+        bool: {
+          must: []
+        }
       }
     }
   };
 
   switch (index) {
     case 'projects':
-      params.body.query.match = { content: { query: term, fuzziness: 'AUTO' } };
+      params.body.query.bool.must.push({ match: { search: { query: term, fuzziness: 'AUTO' } } });
       break;
 
     default:
-      params.body.query.match = { name: { query: term, fuzziness: 'AUTO' } };
+      params.body.query.bool.must.push({ match: { name: { query: term, fuzziness: 'AUTO' } } });
       break;
   }
 
+  if (filters.status) {
+    params.body.query.bool.filter = { term: { status: filters.status[0] } };
+  }
+
   return Promise.resolve()
-    .then(() => client.search(params));
+    .then(() => client.search(params))
+    .then(result => {
+      return client.count({ index })
+        .then(count => {
+          result.body.count = count.body.count;
+          return result;
+        });
+    });
 };
 
 module.exports.indexes = indexes;

--- a/lib/search.js
+++ b/lib/search.js
@@ -27,7 +27,8 @@ module.exports = (client) => (term, index = 'projects', filters = {}) => {
       break;
   }
 
-  if (filters.status) {
+
+  if (filters.status && index !== 'profiles') {
     params.body.query.bool.filter = { term: { status: filters.status[0] } };
   }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -17,14 +17,16 @@ module.exports = (client) => (term, index = 'projects', filters = {}) => {
     }
   };
 
-  switch (index) {
-    case 'projects':
-      params.body.query.bool.must.push({ match: { search: { query: term, fuzziness: 'AUTO' } } });
-      break;
+  if (term) {
+    switch (index) {
+      case 'projects':
+        params.body.query.bool.must.push({ match: { search: { query: term, fuzziness: 'AUTO' } } });
+        break;
 
-    default:
-      params.body.query.bool.must.push({ match: { name: { query: term, fuzziness: 'AUTO' } } });
-      break;
+      default:
+        params.body.query.bool.must.push({ match: { name: { query: term, fuzziness: 'AUTO' } } });
+        break;
+    }
   }
 
 


### PR DESCRIPTION
The scope of this expanded a little. It now does:

* Add support for status filters
* Return all results if no search term
* Reduce scope of project search to limited fields (leaves full content index in place though)