### PR TITLE
Check status filter has a value before applying it

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -42,7 +42,7 @@ module.exports = (client) => (term, index = 'projects', filters = {}) => {
     });
   }
 
-  if (filters.status && index !== 'profiles') {
+  if (filters.status && filters.status[0] && index !== 'profiles') {
     params.body.query.bool.filter = { term: { status: filters.status[0] } };
   }
 


### PR DESCRIPTION
When the "All" filter is clicked the request has a status filter of `['']`. Don't apply an empty string to the query in that case.