### PR TITLE
Only set minimum_should_match if there is a search term

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -34,8 +34,7 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
       sort,
       query: {
         bool: {
-          should: [],
-          minimum_should_match: 1
+          should: []
         }
       },
       _source: {
@@ -45,6 +44,8 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
   };
 
   if (term) {
+
+    params.body.query.bool.minimum_should_match = 1;
 
     if (index === 'projects' && term.match(/^content:/)) {
       // do a full content search


### PR DESCRIPTION
Otherwise the status filters on an empty search return zero results as there are no "should" clauses to match.