### PR TITLE
Re-use elastic-search client

### DIFF
--- a/lib/router/search.js
+++ b/lib/router/search.js
@@ -7,9 +7,10 @@ const search = require('../search');
 module.exports = (settings) => {
   const app = Router();
 
+  const client = createESClient(settings.es);
+
   app.use((req, res, next) => {
-    return Promise.resolve()
-      .then(() => createESClient(settings.es))
+    return Promise.resolve(client)
       .then(esClient => {
         req.search = search(esClient);
       })


### PR DESCRIPTION
Instead of creating a new client for every request allow a single client to be used for all requests