### PR TITLE
Add endpoint to re-index a specific record

### DIFF
--- a/bin/indexer
+++ b/bin/indexer
@@ -30,19 +30,7 @@ Promise.resolve()
       }
       return Promise.resolve()
         .then(() => {
-          if (args.reset) {
-            console.log(`Resetting index ${green(key)}`);
-            return esClient.indices.delete({ index: key })
-              .catch(e => {
-                if (get(e, 'body.error.type') === 'index_not_found_exception') {
-                  return;
-                }
-                throw e;
-              });
-          }
-        })
-        .then(() => {
-          return indexer(db, esClient);
+          return indexer(db, esClient, args);
         })
         .then(() => {
           console.log(`Completed index ${green(key)}`);

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,13 +1,15 @@
 const api = require('@asl/service/api');
 const errorHandler = require('@asl/service/lib/error-handler');
 const { NotFoundError } = require('@asl/service/errors');
-const searchRouter = require('./router/search');
+const search = require('./router/search');
+const indexer = require('./router/indexer');
 
 module.exports = (settings) => {
 
   const app = api(settings);
 
-  app.use('/', searchRouter(settings));
+  app.use('/', search(settings));
+  app.use('/', indexer(settings));
 
   app.use((req, res, next) => {
     if (res.response) {

--- a/lib/indexers/projects.js
+++ b/lib/indexers/projects.js
@@ -62,11 +62,16 @@ const indexProject = (esClient, project, ProjectVersion) => {
     });
 };
 
-module.exports = (db, esClient) => {
-  const { Project, ProjectVersion } = db;
-
+const reset = esClient => {
+  console.log(`Rebuilding index ${indexName}`);
   return Promise.resolve()
-    .then(() => esClient.indices.delete({ index: indexName }).catch(() => {}))
+    .then(() => esClient.indices.delete({ index: indexName }))
+    .catch(e => {
+      if (get(e, 'body.error.type') === 'index_not_found_exception') {
+        return;
+      }
+      throw e;
+    })
     .then(() => {
       return esClient.indices.create({
         index: indexName,
@@ -125,10 +130,30 @@ module.exports = (db, esClient) => {
           }
         }
       });
+    });
+}
+
+module.exports = (db, esClient, options) => {
+  const { Project, ProjectVersion } = db;
+
+  if (options.reset && options.id) {
+    throw new Error('Do not define an id when resetting indexes');
+  }
+
+  return Promise.resolve()
+    .then(() => {
+      if (options.reset) {
+        return reset(esClient);
+      }
     })
     .then(() => {
       return Project.query()
         .select(columnsToIndex)
+        .where(builder => {
+          if (options.id) {
+            builder.where({ id: options.id });
+          }
+        })
         .withGraphFetched('[licenceHolder, establishment]')
         .whereExists(
           Project.relatedQuery('version').where('status', '!=', 'draft')

--- a/lib/router/indexer.js
+++ b/lib/router/indexer.js
@@ -1,0 +1,40 @@
+const { Router } = require('express');
+const isUUID = require('uuid-validate');
+const Schema = require('@asl/schema');
+const { NotFoundError, BadRequestError } = require('@asl/service/errors');
+const { createESClient } = require('../elasticsearch');
+const indexers = require('../indexers');
+
+module.exports = (settings) => {
+  const app = Router();
+
+  const client = createESClient(settings.es);
+  const db = Schema(settings.db);
+
+  app.param('index', (req, res, next, param) => {
+    if (!indexers[param]) {
+      throw new NotFoundError();
+    }
+    next();
+  });
+
+  app.param('id', (req, res, next, param) => {
+    if (!isUUID(param)) {
+      throw new BadRequestError();
+    }
+    next();
+  });
+
+  app.put('/:index/:id', (req, res, next) => {
+    return Promise.resolve(client)
+      .then(esClient => {
+        return indexers[req.params.index](db, esClient, { id: req.params.id });
+      })
+      .then(() => {
+        res.json({ message: `Re-indexed ${req.params.index}:${req.params.id}` });
+      })
+      .catch(next);
+  });
+
+  return app;
+};


### PR DESCRIPTION
Can hit `/establishments/:id` `/projects/:id` or `/profiles/:id` to refresh the index for a particular record without needing to rebuild the entire index.

The eventual use-case for this will be a workflow hook that refreshes the index on those entities whenever a task resolves that would update the data.