### PR TITLE
Don't validate UUID

### DIFF
--- a/lib/indexers/profiles.js
+++ b/lib/indexers/profiles.js
@@ -90,6 +90,7 @@ module.exports = (schema, esClient, options = {}) => {
         .withGraphFetched('[establishments,pil]');
     })
     .then(profiles => {
+      console.log(`Indexing ${profiles.length} profiles`);
       return profiles.reduce((p, profile) => {
         return p.then(() => indexProfile(esClient, profile));
       }, Promise.resolve());

--- a/lib/router/indexer.js
+++ b/lib/router/indexer.js
@@ -1,7 +1,7 @@
 const { Router } = require('express');
 const isUUID = require('uuid-validate');
 const Schema = require('@asl/schema');
-const { NotFoundError, BadRequestError } = require('@asl/service/errors');
+const { NotFoundError } = require('@asl/service/errors');
 const { createESClient } = require('../elasticsearch');
 const indexers = require('../indexers');
 
@@ -14,13 +14,6 @@ module.exports = (settings) => {
   app.param('index', (req, res, next, param) => {
     if (!indexers[param]) {
       throw new NotFoundError();
-    }
-    next();
-  });
-
-  app.param('id', (req, res, next, param) => {
-    if (!isUUID(param)) {
-      throw new BadRequestError();
     }
     next();
   });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon -r dotenv/config"
+    "dev": "nodemon -r dotenv/config",
+    "indexer": "bin/indexer"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Establishment ids are not UUIDs so can't be validated as such

Also clean up some things that go t lost in earlier PRs:

* logging counts consistently in indexer
* restore npm script for indexer so that conductor works properly