### PR TITLE
Split search term into words and combine with AND

### DIFF
--- a/lib/indexers/projects.js
+++ b/lib/indexers/projects.js
@@ -97,7 +97,7 @@ const reset = esClient => {
               licenceHolder: {
                 properties: {
                   lastName: {
-                    type: 'keyword',
+                    type: 'text',
                     fields: {
                       value: {
                         type: 'keyword'

--- a/lib/search.js
+++ b/lib/search.js
@@ -45,9 +45,11 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
 
   if (term) {
 
-    params.body.query.bool.minimum_should_match = 1;
+    const words = term.split(' ');
+
 
     if (index === 'projects' && term.match(/^content:/)) {
+      params.body.query.bool.minimum_should_match = 1;
       // do a full content search
       params.body.query.bool.should.push({
         multi_match: {
@@ -59,43 +61,53 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
         }
       });
     } else {
+      params.body.query.bool.minimum_should_match = words.length;
       // search subset of fields
       let fields;
       switch (index) {
         case 'projects':
           fields = [
-            'title^2',
+            'title',
             'licenceHolder.lastName',
             'establishment.name',
             'content.keywords*'
           ];
+
           params.body.query.bool.should.push({
             match: { licenceNumber: term }
           });
           break;
 
         case 'profiles':
-          fields = ['firstName', 'lastName^2', 'email'];
+          fields = [
+            'firstName',
+            'lastName^2',
+            'email'
+          ];
           params.body.query.bool.should.push({
             match: { 'pil.licenceNumber': term }
           });
           break;
 
         case 'establishments':
-          fields = ['name'];
+          fields = [
+            'name'
+          ];
           params.body.query.bool.should.push({
             match: { licenceNumber: term }
           });
           break;
       }
-      params.body.query.bool.should.push({
-        multi_match: {
-          fields,
-          query: term,
-          fuzziness: 'auto'
-        }
-      });
-
+      words.forEach(word => {
+        params.body.query.bool.should.push({
+          multi_match: {
+            fields,
+            query: word,
+            fuzziness: 'AUTO',
+            operator: 'and'
+          }
+        });
+      })
     }
 
   }


### PR DESCRIPTION
If a user enters a search term with multiple words then run a separate search for each word and require that all words match in a result.

This means that adding additional search terms will make a search more specific rather than less specific, which aligns better with user expectations.