### PR TITLE
Return dynamic list of statuses

### DIFF
--- a/lib/indexers/projects.js
+++ b/lib/indexers/projects.js
@@ -94,6 +94,9 @@ const reset = esClient => {
                   }
                 }
               },
+              status: {
+                type: 'keyword'
+              },
               licenceHolder: {
                 properties: {
                   lastName: {

--- a/lib/router/search.js
+++ b/lib/router/search.js
@@ -34,6 +34,7 @@ module.exports = (settings) => {
       .then(response => {
         res.response = response.body.hits.hits.map(r => r._source);
         res.meta = {
+          filters: response.body.statuses,
           total: response.body.count,
           count: response.body.hits.total.value,
           maxScore: response.body.hits.max_score
@@ -47,18 +48,6 @@ module.exports = (settings) => {
         }
         return next(e);
       });
-  });
-
-  app.get('/:index', (req, res, next) => {
-    switch (req.params.index) {
-      case 'establishments':
-        res.meta.filters = ['active', 'inactive', 'revoked'];
-        break;
-      case 'projects':
-        res.meta.filters = ['active', 'inactive', 'expired', 'revoked', 'transferred'];
-        break;
-    }
-    next();
   });
 
   return app;


### PR DESCRIPTION
Rather than hard-coding the list, use an aggregator query to get the complete set of statuses present in the data-set.