### PR TITLE
Set maximum fields to 2000 on projects index

### DIFF
--- a/lib/indexers/projects.js
+++ b/lib/indexers/projects.js
@@ -76,6 +76,9 @@ const reset = esClient => {
       return esClient.indices.create({
         index: indexName,
         body: {
+          settings: {
+            'index.mapping.total_fields.limit': 2000
+          },
           mappings: {
             properties: {
               title: {


### PR DESCRIPTION
The default is 1000, which causes the indexxer to fail on preprod.