### PR TITLE
Improve error logging for elastic errors

### DIFF
--- a/lib/errors/elastic.js
+++ b/lib/errors/elastic.js
@@ -1,0 +1,10 @@
+class ElasticError extends Error {
+
+  constructor(options) {
+    super(`${options.type}: ${options.reason}`);
+    Object.assign(this, options);
+  }
+
+}
+
+module.exports = ElasticError;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -1,0 +1,7 @@
+const errors = require('@asl/service/errors');
+const ElasticError = require('./elastic');
+
+module.exports = {
+  ...errors,
+  ElasticError
+};

--- a/lib/router/search.js
+++ b/lib/router/search.js
@@ -1,6 +1,6 @@
 const { get } = require('lodash');
 const { Router } = require('express');
-const { NotFoundError } = require('@asl/service/errors');
+const { ElasticError, NotFoundError } = require('../errors');
 const { createESClient } = require('../elasticsearch');
 const search = require('../search');
 
@@ -44,7 +44,7 @@ module.exports = (settings) => {
       .catch(e => {
         const error = get(e, 'meta.body.error');
         if (error) {
-          return next(new Error(`${error.type}: ${error.reason}`));
+          return next(new ElasticError(error));
         }
         return next(e);
       });


### PR DESCRIPTION
We were losing a lot of metadata from the elastic error by flattening it to single string. Instead add the entire error data to the error object so it can be logged.