### PR TITLE
Limit project index to only rich text inputs

### DIFF
--- a/bin/search
+++ b/bin/search
@@ -30,7 +30,7 @@ Promise.resolve()
   .then(search => search(term, index))
   .then(response => {
     const count = response.body.hits.total.value;
-    response.body.hits.hits.forEach(h => console.log(h._source));
+    response.body.hits.hits.forEach(h => console.log({ ...h._source, highlight: h.highlight }));
 
     const end = process.hrtime(start);
     console.log(`\nFound ${green(count)} result${count === 1 ? '' : 's'}`);

--- a/lib/router/search.js
+++ b/lib/router/search.js
@@ -32,7 +32,7 @@ module.exports = (settings) => {
     return Promise.resolve()
       .then(() => req.search(term, index, req.query))
       .then(response => {
-        res.response = response.body.hits.hits.map(r => r._source);
+        res.response = response.body.hits.hits.map(r => ({ ...r._source, highlight: r.highlight }));
         res.meta = {
           filters: response.body.statuses,
           total: response.body.count,

--- a/lib/search.js
+++ b/lib/search.js
@@ -72,6 +72,11 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
           operator: 'and'
         }
       });
+      params.body.highlight = {
+        fields: {
+          'content.*': {}
+        }
+      };
     } else {
       params.body.query.bool.minimum_should_match = words.length;
       // search subset of fields

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chalk": "^4.0.0",
     "express": "^4.17.1",
     "lodash": "^4.17.15",
+    "minimatch": "^3.0.4",
     "minimist": "^1.2.5",
     "slate": "^0.47.8",
     "uuid-validate": "0.0.3"


### PR DESCRIPTION
Allows adding custom extra fields to index as well as rte content, but otherwise ignores all non-RTE data.

Also includes matching field data in full content search response.