### PR TITLE
Increase max results window setting for profiles index

### DIFF
--- a/lib/indexers/profiles.js
+++ b/lib/indexers/profiles.js
@@ -30,6 +30,9 @@ const reset = esClient => {
       return esClient.indices.create({
         index: indexName,
         body: {
+          settings: {
+            'index.max_result_window': 30000
+          },
           mappings: {
             properties: {
               lastName: {

--- a/lib/router/search.js
+++ b/lib/router/search.js
@@ -39,6 +39,9 @@ module.exports = (settings) => {
           count: response.body.hits.total.value,
           maxScore: response.body.hits.max_score
         };
+        if (response.body.hits.total.relation === 'gte') {
+          res.meta.count = res.meta.total;
+        }
       })
       .then(() => next())
       .catch(e => {


### PR DESCRIPTION
This allows the complete set of profile data from prod to be included in a search. It can result in an increase increase in resource usage and impaired performance, but testing locally on a ~30,000 record dataset with a less powerful elastic instance than prod works fine - presumably because the index data is still small (~5mb total size).

Over 10,000 results the results counter loses accuracy and only returns a count of `gte` 10000, so if that happens then reset the result counter to assume we're getting all the results, because in 100% of our use cases that's what is happening.