### PR TITLE
Add partial substring matching to establishment search

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -93,7 +93,16 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
           'name'
         ];
         params.body.query.bool.should.push({
-          match: { licenceNumber: term }
+          wildcard: {
+            name: {
+              value: `${term}*`
+            }
+          }
+        });
+        params.body.query.bool.should.push({
+          match: {
+            licenceNumber: term
+          }
         });
         break;
     }


### PR DESCRIPTION
This enable searching for a partial establishment name - for example `croy` will match `University of Croydon`.

This better matches user behaviour in prod where ASRU users input the first few characters of an establishment and hit enter.