### PR TITLE
Allow matching establishments by ASRU assignment

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -90,7 +90,8 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
 
       case 'establishments':
         fields = [
-          'name'
+          'name^2',
+          'asru.*Name'
         ];
         params.body.query.bool.should.push({
           wildcard: {


### PR DESCRIPTION
Can search for the name of a SPoC or Inspector in the establishment search and get a list of their establishments. Boost the establishment name so name matches appear first if they exist.