### PR TITLE
Normalise licence numbers to uppercase

### DIFF
--- a/lib/indexers/establishments.js
+++ b/lib/indexers/establishments.js
@@ -9,6 +9,7 @@ const indexEstablishment = (esClient, establishment) => {
     id: establishment.id,
     body: {
       ...pick(establishment, columnsToIndex),
+      licenceNumber: establishment.licenceNumber ? establishment.licenceNumber.toUpperCase() : null,
       asru: establishment.asru.map(p => pick(p, 'id', 'firstName', 'lastName', 'asruInspector', 'asruLicensing'))
     }
   });

--- a/lib/indexers/profiles.js
+++ b/lib/indexers/profiles.js
@@ -11,7 +11,9 @@ const indexProfile = (esClient, profile) => {
       ...pick(profile, columnsToIndex),
       name: `${profile.firstName} ${profile.lastName}`,
       establishments: profile.establishments.map(e => pick(e, 'id', 'name')),
-      pil: pick(profile.pil, 'licenceNumber')
+      pil: {
+        licenceNumber: get(profile, 'pil.licenceNumber', '').toUpperCase()
+      }
     }
   });
 };

--- a/lib/indexers/projects/index.js
+++ b/lib/indexers/projects/index.js
@@ -21,6 +21,7 @@ const indexProject = (esClient, project, ProjectVersion) => {
         id: project.id,
         body: {
           ...pick(project, columnsToIndex),
+          licenceNumber: project.licenceNumber ? project.licenceNumber.toUpperCase() : null,
           licenceHolder: pick(project.licenceHolder, 'id', 'firstName', 'lastName'),
           establishment: pick(project.establishment, 'id', 'name'),
           keywords: data.keywords,

--- a/lib/search.js
+++ b/lib/search.js
@@ -73,7 +73,9 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
         ];
 
         params.body.query.bool.should.push({
-          match: { licenceNumber: term }
+          match: {
+            licenceNumber: term.toUpperCase()
+          }
         });
         break;
 
@@ -84,7 +86,9 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
           'email'
         ];
         params.body.query.bool.should.push({
-          match: { 'pil.licenceNumber': term }
+          match: {
+            'pil.licenceNumber': term.toUpperCase()
+          }
         });
         break;
 
@@ -102,7 +106,7 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
         });
         params.body.query.bool.should.push({
           match: {
-            licenceNumber: term
+            licenceNumber: term.toUpperCase()
           }
         });
         break;


### PR DESCRIPTION
Licence number matches are strictly case sensitive, so index as uppercase always and search as uppercase.