### PR TITLE
Set non-licence number search terms to lower case

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -100,7 +100,7 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
         params.body.query.bool.should.push({
           wildcard: {
             name: {
-              value: `${term}*`
+              value: `${term.toLowerCase()}*`
             }
           }
         });
@@ -115,7 +115,7 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
       params.body.query.bool.should.push({
         multi_match: {
           fields,
-          query: word,
+          query: word.toLowerCase(),
           fuzziness: 'AUTO',
           operator: 'and'
         }


### PR DESCRIPTION
This ensures consistent results irrespective of the casing used in the input.