### PR TITLE
Handle null PIL licence numbers

### DIFF
--- a/lib/indexers/profiles.js
+++ b/lib/indexers/profiles.js
@@ -4,6 +4,7 @@ const indexName = 'profiles';
 const columnsToIndex = ['id', 'title', 'firstName', 'lastName', 'email', 'telephone', 'telephoneAlt', 'postcode'];
 
 const indexProfile = (esClient, profile) => {
+  const pilNumber = get(profile, 'pil.licenceNumber');
   return esClient.index({
     index: indexName,
     id: profile.id,
@@ -12,7 +13,7 @@ const indexProfile = (esClient, profile) => {
       name: `${profile.firstName} ${profile.lastName}`,
       establishments: profile.establishments.map(e => pick(e, 'id', 'name')),
       pil: {
-        licenceNumber: get(profile, 'pil.licenceNumber', '').toUpperCase()
+        licenceNumber: pilNumber ? pilNumber.toUpperCase() : null
       }
     }
   });


### PR DESCRIPTION
Lodash.get returns null if a property is explicitly null rather than the default, so PILs without licence numbers (partial applications) threw an error.