### PR TITLE
Add additional weight to first name matches

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -81,7 +81,7 @@ module.exports = (client) => (term, index = 'projects', query = {}) => {
 
       case 'profiles':
         fields = [
-          'firstName',
+          'firstName^1.8',
           'lastName^2',
           'email'
         ];


### PR DESCRIPTION
Currently a close match on the surname comes ahead of an exact match on the first name, which is unexpected. Boost the first name so that an exact match will come in front of fuzzy surname matches.