### PR TITLE
Apply status filters to all searches

### DIFF
--- a/lib/search/establishments.js
+++ b/lib/search/establishments.js
@@ -8,11 +8,15 @@ module.exports = client => async (term = '', query = {}) => {
     ...sortParams(term, query)
   };
 
+  params.body.query = { bool: {} };
+
+  if (query.filters && query.filters.status && query.filters.status[0]) {
+    params.body.query.bool.filter = { term: { status: query.filters.status[0] } };
+  }
+
   if (!term) {
     return client.search(params);
   }
-
-  params.body.query = {};
 
   // search subset of fields
   const fields = [
@@ -52,10 +56,6 @@ module.exports = client => async (term = '', query = {}) => {
       }))
     ]
   };
-
-  if (query.filters && query.filters.status && query.filters.status[0]) {
-    params.body.query.bool.filter = { term: { status: query.filters.status[0] } };
-  }
 
   return client.search(params);
 };

--- a/lib/search/projects.js
+++ b/lib/search/projects.js
@@ -8,11 +8,15 @@ module.exports = client => async (term = '', query = {}) => {
     ...sortParams(term, query)
   };
 
+  params.body.query = { bool: {} };
+
+  if (query.filters && query.filters.status && query.filters.status[0]) {
+    params.body.query.bool.filter = { term: { status: query.filters.status[0] } };
+  }
+
   if (!term) {
     return client.search(params);
   }
-
-  params.body.query = {};
 
   // search subset of fields
   const fields = [
@@ -46,10 +50,6 @@ module.exports = client => async (term = '', query = {}) => {
       }))
     ]
   };
-
-  if (query.filters && query.filters.status && query.filters.status[0]) {
-    params.body.query.bool.filter = { term: { status: query.filters.status[0] } };
-  }
 
   return client.search(params);
 };


### PR DESCRIPTION
The search function was returning early if there is no search term, which was not applying status filters. Move the status filter to before the early return.