### PR TITLE
Don't reset query when there is a search term

### DIFF
--- a/lib/search/establishments.js
+++ b/lib/search/establishments.js
@@ -27,35 +27,33 @@ module.exports = client => async (term = '', query = {}) => {
   const tokeniser = await client.indices.analyze({ index, body: { text: term } });
   const tokens = tokeniser.body.tokens.map(t => t.token);
 
-  params.body.query.bool = {
-    minimum_should_match: tokens.length,
-    should: [
-      ...tokens.map(token => ({
-        match: {
-          licenceNumber: {
-            query: token,
-            boost: 2
-          }
-        }
-      })),
-      ...tokens.map(token => ({
-        multi_match: {
-          fields,
+  params.body.query.bool.minimum_should_match = tokens.length;
+  params.body.query.bool.should = [
+    ...tokens.map(token => ({
+      match: {
+        licenceNumber: {
           query: token,
-          fuzziness: 'AUTO',
-          operator: 'and',
-          boost: 1.5
+          boost: 2
         }
-      })),
-      ...tokens.map(token => ({
-        wildcard: {
-          name: {
-            value: `${token}*`
-          }
+      }
+    })),
+    ...tokens.map(token => ({
+      multi_match: {
+        fields,
+        query: token,
+        fuzziness: 'AUTO',
+        operator: 'and',
+        boost: 1.5
+      }
+    })),
+    ...tokens.map(token => ({
+      wildcard: {
+        name: {
+          value: `${token}*`
         }
-      }))
-    ]
-  };
+      }
+    }))
+  ];
 
   return client.search(params);
 };

--- a/lib/search/profiles.js
+++ b/lib/search/profiles.js
@@ -12,8 +12,6 @@ module.exports = client => async (term = '', query = {}) => {
     return client.search(params);
   }
 
-  params.body.query = {};
-
   // search subset of fields
   const fields = [
     'firstName^1.8',
@@ -24,23 +22,25 @@ module.exports = client => async (term = '', query = {}) => {
   const tokeniser = await client.indices.analyze({ index, body: { text: term } });
   const tokens = tokeniser.body.tokens.map(t => t.token);
 
-  params.body.query.bool = {
-    minimum_should_match: tokens.length,
-    should: [
-      ...tokens.map(token => ({
-        match: {
-          'pil.licenceNumber': token
-        }
-      })),
-      ...tokens.map(token => ({
-        multi_match: {
-          fields,
-          query: token,
-          fuzziness: 'AUTO',
-          operator: 'and'
-        }
-      }))
-    ]
+  params.body.query = {
+    bool: {
+      minimum_should_match: tokens.length,
+      should: [
+        ...tokens.map(token => ({
+          match: {
+            'pil.licenceNumber': token
+          }
+        })),
+        ...tokens.map(token => ({
+          multi_match: {
+            fields,
+            query: token,
+            fuzziness: 'AUTO',
+            operator: 'and'
+          }
+        }))
+      ]
+    }
   };
 
   return client.search(params);

--- a/lib/search/projects.js
+++ b/lib/search/projects.js
@@ -29,27 +29,25 @@ module.exports = client => async (term = '', query = {}) => {
   const tokeniser = await client.indices.analyze({ index, body: { text: term } });
   const tokens = tokeniser.body.tokens.map(t => t.token);
 
-  params.body.query.bool = {
-    minimum_should_match: tokens.length,
-    should: [
-      ...tokens.map(token => ({
-        match: {
-          licenceNumber: {
-            query: token,
-            boost: 2
-          }
-        }
-      })),
-      ...tokens.map(token => ({
-        multi_match: {
-          fields,
+  params.body.query.bool.minimum_should_match = tokens.length;
+  params.body.query.bool.should = [
+    ...tokens.map(token => ({
+      match: {
+        licenceNumber: {
           query: token,
-          fuzziness: 'AUTO',
-          operator: 'and'
+          boost: 2
         }
-      }))
-    ]
-  };
+      }
+    })),
+    ...tokens.map(token => ({
+      multi_match: {
+        fields,
+        query: token,
+        fuzziness: 'AUTO',
+        operator: 'and'
+      }
+    }))
+  ];
 
   return client.search(params);
 };


### PR DESCRIPTION
The code to handle a defined search term was removing the earlier status filter. Instead extend the query with additional parameters.