### PR TITLE
Use standard tokeniser for profile names

### DIFF
--- a/lib/indexers/profiles/index.js
+++ b/lib/indexers/profiles/index.js
@@ -43,11 +43,11 @@ const reset = esClient => {
                   filter: ['lowercase']
                 },
                 name: {
-                  tokenizer: 'whitespace',
+                  tokenizer: 'standard',
                   filter: ['lowercase', 'asciifolding']
                 },
                 firstname: {
-                  tokenizer: 'whitespace',
+                  tokenizer: 'standard',
                   filter: ['lowercase', 'asciifolding', 'synonyms']
                 }
               },


### PR DESCRIPTION
The whitespace tokeniser preserves double-barrelled names so they only match if searched on the complete name with hyphen and not either part.

Instead use the standard tokeniser so that either barrel will match, as will omitting the hyphen.