### PR TITLE
Add PIL licence number to indexed fields in profile search

### DIFF
--- a/lib/indexers/profiles/index.js
+++ b/lib/indexers/profiles/index.js
@@ -2,7 +2,17 @@ const { pick, get } = require('lodash');
 const synonyms = require('./synonyms');
 
 const indexName = 'profiles';
-const columnsToIndex = ['id', 'title', 'firstName', 'lastName', 'email', 'telephone', 'telephoneAlt', 'postcode'];
+const columnsToIndex = [
+  'id',
+  'title',
+  'firstName',
+  'lastName',
+  'email',
+  'telephone',
+  'telephoneAlt',
+  'postcode',
+  'pilLicenceNumber'
+];
 
 const indexProfile = (esClient, profile) => {
   return esClient.index({


### PR DESCRIPTION
The field was not included in the initial `select` so was not being indexed and search by PIL licence number was returning no results.