### PR TITLE
Filter sortable columns for result sorting

### DIFF
--- a/lib/search/establishments.js
+++ b/lib/search/establishments.js
@@ -1,11 +1,12 @@
 const sortParams = require('./sort-params');
 
 const index = 'establishments';
+const sortable = ['name', 'status'];
 
 module.exports = client => async (term = '', query = {}) => {
   const params = {
     index,
-    ...sortParams(term, query)
+    ...sortParams(term, query, sortable)
   };
 
   params.body.query = { bool: {} };

--- a/lib/search/profiles.js
+++ b/lib/search/profiles.js
@@ -1,11 +1,12 @@
 const sortParams = require('./sort-params');
 
 const index = 'profiles';
+const sortable = ['lastName', 'email'];
 
 module.exports = client => async (term = '', query = {}) => {
   const params = {
     index,
-    ...sortParams(term, query)
+    ...sortParams(term, query, sortable)
   };
 
   if (!term) {

--- a/lib/search/projects.js
+++ b/lib/search/projects.js
@@ -1,11 +1,12 @@
 const sortParams = require('./sort-params');
 
 const index = 'projects';
+const sortable = ['title', 'licenceHolder.lastName', 'establishment.name', 'licenceNumber', 'status', 'expiryDate'];
 
 module.exports = client => async (term = '', query = {}) => {
   const params = {
     index,
-    ...sortParams(term, query)
+    ...sortParams(term, query, sortable)
   };
 
   params.body.query = { bool: {} };

--- a/lib/search/sort-params.js
+++ b/lib/search/sort-params.js
@@ -1,12 +1,12 @@
-module.exports = (term = '', query = {}, defaults) => {
+module.exports = (term = '', query = {}, columns) => {
   let sort;
   const size = parseInt(query.limit, 10) || 10;
   const from = parseInt(query.offset, 10) || 0;
 
-  if (query.sort) {
-    sort = { [`${query.sort.column}.value`]: query.sort.ascending === 'true' ? 'asc' : 'desc' };
-  } else if (!term) {
-    sort = defaults;
+  if (query.sort && query.sort.column) {
+    if (columns.includes(query.sort.column)) {
+      sort = { [`${query.sort.column}.value`]: query.sort.ascending === 'true' ? 'asc' : 'desc' };
+    }
   }
 
   return {


### PR DESCRIPTION
This throws an error if an undefined column is used to apply a sort. Prevent that by ignoring sort parameters if the column defined is not sortable.