### PR TITLE
Handle expired AWS credentials

### DIFF
--- a/lib/elasticsearch/index.js
+++ b/lib/elasticsearch/index.js
@@ -1,6 +1,6 @@
 const AWS = require('aws-sdk');
 const { Client } = require('@elastic/elasticsearch');
-const { createAWSConnection, awsGetCredentials } = require('@acuris/aws-es-connection');
+const { createAWSConnection, awsGetCredentials, awsCredsifyAll } = require('@acuris/aws-es-connection');
 
 const createESClient = async (options) => {
   if (options.aws.credentials.key) {
@@ -14,10 +14,10 @@ const createESClient = async (options) => {
     const awsCredentials = await awsGetCredentials();
     const AWSConnection = createAWSConnection(awsCredentials);
 
-    return new Client({
+    return awsCredsifyAll(new Client({
       ...options.aws.client,
       Connection: AWSConnection
-    });
+    }));
   }
 
   // no AWS vars set, attempt local connection


### PR DESCRIPTION
AWS signed credentials have a TTL and at the moment if that expires then the service stops working until it is restarted.

Use the wrapper function in the AWS credentials library that solves this precise problem - https://github.com/mergermarket/acuris-aws-es-connection/tree/v1.1.0#how-does-it-work