### PR TITLE
Apply default sort order to empty search

### DIFF
--- a/lib/search/sort-params.js
+++ b/lib/search/sort-params.js
@@ -1,7 +1,11 @@
 module.exports = (term = '', query = {}, columns) => {
-  let sort;
+  let sort = {};
   const size = parseInt(query.limit, 10) || 10;
   const from = parseInt(query.offset, 10) || 0;
+
+  if (!term) {
+    sort[`${columns[0]}.value`] = 'asc';
+  }
 
   if (query.sort && query.sort.column) {
     if (columns.includes(query.sort.column)) {


### PR DESCRIPTION
This means that when hitting the search pages without a term entered the results will always be ordered in the same way (by name/title).

Specifically it means the visual regressions won't throw false positives because the result ordering is random.