### PR TITLE
Update elastic client

### DIFF
--- a/lib/elasticsearch/index.js
+++ b/lib/elasticsearch/index.js
@@ -1,6 +1,6 @@
 const AWS = require('aws-sdk');
 const { Client } = require('@elastic/elasticsearch');
-const { createAWSConnection, awsGetCredentials, awsCredsifyAll } = require('@acuris/aws-es-connection');
+const { createAWSConnection, awsGetCredentials } = require('@acuris/aws-es-connection');
 
 const createESClient = async (options) => {
   if (options.aws.credentials.key) {
@@ -14,10 +14,10 @@ const createESClient = async (options) => {
     const awsCredentials = await awsGetCredentials();
     const AWSConnection = createAWSConnection(awsCredentials);
 
-    return awsCredsifyAll(new Client({
+    return new Client({
       ...options.aws.client,
       Connection: AWSConnection
-    }));
+    });
   }
 
   // no AWS vars set, attempt local connection

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@acuris/aws-es-connection": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@acuris/aws-es-connection/-/aws-es-connection-1.1.0.tgz",
-      "integrity": "sha512-R5g5EqCImRO/uQcmoCyYwSbX5QZPtluq7Xo4VjwHXz9jxWjs6Slufcghf/m3dPDm1IIzPDqHyNxMRf+fis63Ew==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@acuris/aws-es-connection/-/aws-es-connection-2.0.1.tgz",
+      "integrity": "sha512-wY+jp2kUNVClICpTeAiNU18Nu2zrU6MYzook/V4IdCGtuQCwEPP63ef6LEIE6DAYY9zKY+j0KPQthlJbhHtG1w==",
       "requires": {
         "aws4": "^1.8.0"
       }
@@ -1567,9 +1567,9 @@
       }
     },
     "aws4": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
     },
     "babel-code-frame": {
       "version": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@acuris/aws-es-connection": "^1.1.0",
+    "@acuris/aws-es-connection": "^2.0.1",
     "@asl/constants": "^0.7.1",
     "@asl/schema": "^9.1.0",
     "@asl/service": "^7.21.2",


### PR DESCRIPTION
The `awsCredsifyAll` function did not do what it claimed, and has disappeared in the latest version. Use that in the futile hope that it actually works.