### PR TITLE
Remove ASRU users from index

### DIFF
--- a/lib/indexers/profiles/index.js
+++ b/lib/indexers/profiles/index.js
@@ -11,8 +11,7 @@ const columnsToIndex = [
   'telephone',
   'telephoneAlt',
   'postcode',
-  'pilLicenceNumber',
-  'asruUser'
+  'pilLicenceNumber'
 ];
 
 const indexProfile = (esClient, profile) => {
@@ -127,6 +126,7 @@ module.exports = (schema, esClient, options = {}) => {
             builder.where({ id: options.id });
           }
         })
+        .where({ asruUser: false })
         .select(columnsToIndex)
         .withGraphFetched('establishments');
     })

--- a/lib/search/global/profiles.js
+++ b/lib/search/global/profiles.js
@@ -10,15 +10,6 @@ module.exports = client => async (term = '', query = {}) => {
   };
 
   if (!term) {
-    params.body.query = {
-      bool: {
-        filter: {
-          term: {
-            asruUser: false
-          }
-        }
-      }
-    };
     return client.search(params);
   }
 
@@ -34,11 +25,6 @@ module.exports = client => async (term = '', query = {}) => {
 
   params.body.query = {
     bool: {
-      filter: {
-        term: {
-          asruUser: false
-        }
-      },
       minimum_should_match: tokens.length,
       should: [
         ...tokens.map(token => ({


### PR DESCRIPTION
The previous approach was incorrect because it didn't exclude them from the overall count.

Instead simply don't index ASRU users in the first place.