### PR TITLE
Improve CLI search result output

### DIFF
--- a/bin/search
+++ b/bin/search
@@ -19,6 +19,7 @@ const term = args._.join(' ');
 const index = args.index || args.i;
 const estId = args.est || args.e;
 const species = args.species || args.s;
+const aggregate = args.aggregate;
 const estScopedIndexes = ['places'];
 
 if (!term) {
@@ -47,15 +48,15 @@ Promise.resolve()
   })
   .then(response => {
     const count = response.body.hits.total.value;
-    response.body.hits.hits.forEach(h => console.log({ ...h._source, score: h._score, highlight: h.highlight }));
+    response.body.hits.hits.forEach(h => console.log(JSON.stringify({ ...h._source, score: h._score, highlight: h.highlight }, null, '  ')));
 
     const end = process.hrtime(start);
     console.log(`\nFound ${green(count)} result${count === 1 ? '' : 's'}`);
     console.log(`Search took: ${green((end[0] * 1000) + Math.round(end[1] / 1e6))}ms`);
 
-    if (index === 'projects') {
+    if (index === 'projects' && aggregate) {
       console.log(`\nFound ${response.body.species.length} species across all projects:`)
-      console.log(response.body.species);
+      response.body.species.forEach(species => console.log(species));
     }
 
     process.exit();


### PR DESCRIPTION
* `JSON.stringify` results so that they can be piped into `jq` for processing
* Only output aggregated species if requested because they add a lot of noise and get in the way of search results