### PR TITLE
Include restrictions in index of places

### DIFF
--- a/lib/indexers/places/index.js
+++ b/lib/indexers/places/index.js
@@ -1,7 +1,7 @@
 const { pick, get } = require('lodash');
 
 const indexName = 'places';
-const columnsToIndex = ['id', 'establishmentId', 'name', 'site', 'area', 'suitability', 'holding'];
+const columnsToIndex = ['id', 'establishmentId', 'name', 'site', 'area', 'suitability', 'holding', 'restrictions'];
 
 const indexPlace = (esClient, place) => {
   return esClient.index({


### PR DESCRIPTION
These are used in the schedule of premises to render the exclamation indicators where a row has restrictions.