### PR TITLE
Handle null protocols

### DIFF
--- a/lib/indexers/projects-content/extract-content.js
+++ b/lib/indexers/projects-content/extract-content.js
@@ -42,7 +42,7 @@ const getFieldValue = (data, field) => {
 };
 
 const getProtocolsContent = (data, schema) => {
-  const protocols = (data.protocols || []).filter(p => !p.deleted);
+  const protocols = (data.protocols || []).filter(p => p && !p.deleted);
 
   if (!protocols.length) {
     return {};


### PR DESCRIPTION
There are some old projects on preprod which end up having null entries in the protocols array.

Don't try to index those.