### PR TITLE
Index protocols by array index and not id

### DIFF
--- a/lib/indexers/projects-content/extract-content.js
+++ b/lib/indexers/projects-content/extract-content.js
@@ -48,7 +48,7 @@ const getProtocolsContent = (data, schema) => {
     return {};
   }
 
-  return protocols.reduce((map, protocol) => {
+  return protocols.reduce((map, protocol, i) => {
     let value = Object.values(schema.sections).reduce((arr, section) => {
       return [...arr, ...getSectionContent({ ...data, ...protocol }, section)];
     }, [ protocol.title ]);
@@ -61,7 +61,7 @@ const getProtocolsContent = (data, schema) => {
 
     return {
       ...map,
-      [protocol.id]: value
+      [i]: value
     };
   }, {});
 };

--- a/lib/indexers/projects-content/index.js
+++ b/lib/indexers/projects-content/index.js
@@ -24,7 +24,7 @@ const indexProject = (esClient, project, ProjectVersion) => {
       version = version || {};
       const data = version.data || {};
       const content = extractContent(data, project);
-      const protocols = (data.protocols || []).map(p => pick(p, 'id', 'title'));
+      const protocols = (data.protocols || []).filter(p => p && !p.deleted).map(p => pick(p, 'title'));
       return esClient.index({
         index: indexName,
         id: project.id,


### PR DESCRIPTION
Indexing by id results in a field per protocol, and elasticsearch has a 1000 field limit.