### PR TITLE
Remove call to es in healthcheck

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -9,17 +9,7 @@ module.exports = (settings) => {
 
   settings.esClient = createESClient(settings.es);
 
-  const app = api({
-    ...settings,
-    healthcheck: () => {
-      return settings.esClient
-        .then(client => client.info())
-        .catch(err => {
-          console.error(err);
-          throw err;
-        });
-    }
-  });
+  const app = api(settings);
 
   app.use('/', search(settings));
 


### PR DESCRIPTION
This is creating a large number of false positives in dev, resulting in high levels of instability and corresponding failing tests.