### PR TITLE
Set search type when no sort order is defined

### DIFF
--- a/lib/search/helpers/sort-params.js
+++ b/lib/search/helpers/sort-params.js
@@ -26,6 +26,7 @@ module.exports = (query = {}, columns) => {
   return {
     size,
     from,
+    search_type: sort ? undefined : 'dfs_query_then_fetch',
     body: { sort }
   };
 };


### PR DESCRIPTION
Doing relevancy scoring on small indexes doesn't work reliably by default across multiple shards. This means search results can be returned in an unexpected order when sorting by score (default sort).

The workaround for this is to set the search_type property so all shards are queried when assembling statisitics for relevancy scores. Since this has a perf impact but is only relevant when sorting by score set the param only if no specific sort column is defined.