### PR TITLE
Place query was ignoring deleted role joins and including them

### DIFF
--- a/lib/indexers/places/index.js
+++ b/lib/indexers/places/index.js
@@ -145,10 +145,10 @@ module.exports = (schema, esClient, options = {}) => {
       return Place.queryWithDeleted()
         .where(builder => {
           if (options.id) {
-            builder.where({ id: options.id });
+            builder.where({ 'places.id': options.id });
           }
         })
-        .withGraphFetched('[roles.profile]');
+        .joinRoles();
     })
     .then(places => {
       return places.map(place => {


### PR DESCRIPTION
Removed place roles should now be reflected in the search results immediately.