### PR TITLE
Add dates to project content index

### DIFF
--- a/lib/indexers/projects-content/index.js
+++ b/lib/indexers/projects-content/index.js
@@ -7,6 +7,9 @@ const columnsToIndex = [
   'title',
   'status',
   'licenceNumber',
+  'expiryDate',
+  'issueDate',
+  'revocationDate',
   'schemaVersion'
 ];
 


### PR DESCRIPTION
These are now displayed in search results.

There's probably a case for consolidating to a single project index now, but I'll save that for a separate PR.