### PR TITLE
Use standard tokenizer for project content search

### DIFF
--- a/lib/indexers/projects-content/index.js
+++ b/lib/indexers/projects-content/index.js
@@ -62,7 +62,7 @@ const reset = esClient => {
             analysis: {
               analyzer: {
                 default: {
-                  tokenizer: 'whitespace',
+                  tokenizer: 'standard',
                   filter: ['lowercase', 'stop']
                 }
               },


### PR DESCRIPTION
The whitespace tokenizer treats punctuation as significant so words don't match if they precede a full stop or comma or similar.

Using the standard tokenizer means that punctuation is ignored in search matches.