### PR TITLE
Include title matches in project content result highlights

### DIFF
--- a/lib/search/global/projects-content.js
+++ b/lib/search/global/projects-content.js
@@ -12,14 +12,16 @@ module.exports = client => async (term = '', query = {}) => {
     bool: {}
   };
   params.body.highlight = {
+    type: 'plain',
+    fragmenter: 'span',
+    number_of_fragments: 1,
+    pre_tags: '**',
+    post_tags: '**',
+    fragment_size: 250,
     fields: {
-      'content.*': {
-        type: 'plain',
-        fragmenter: 'span',
-        fragment_size: 250,
-        number_of_fragments: 1,
-        pre_tags: '**',
-        post_tags: '**'
+      'content.*': {},
+      'title': {
+        require_field_match: false
       }
     }
   };


### PR DESCRIPTION
This allow search terms that appear in the project title to be specifically highlighted in search results.