### PR TITLE
Add a boost to title matches in full-content project search

### DIFF
--- a/lib/search/global/projects-content.js
+++ b/lib/search/global/projects-content.js
@@ -50,6 +50,14 @@ module.exports = client => async (term = '', query = {}) => {
         type: 'phrase',
         operator: 'and'
       }
+    },
+    {
+      match: {
+        title: {
+          query: term,
+          boost: 1.5
+        }
+      }
     }
   ];
 


### PR DESCRIPTION
This means that projects which match the search term in their title will rank higher than projects where the search term appears in the main body of the application.