### PR TITLE
Assorted full content search improvements

### DIFF
--- a/lib/search/global/projects-content.js
+++ b/lib/search/global/projects-content.js
@@ -5,6 +5,7 @@ const index = 'projects-content';
 module.exports = client => async (term = '', query = {}) => {
   const params = {
     index,
+    timeout: '30s',
     ...sortParams(query, [])
   };
 
@@ -25,6 +26,10 @@ module.exports = client => async (term = '', query = {}) => {
       }
     }
   };
+
+  if (query.limit && parseInt(query.limit, 10) > 100) {
+    params.body.highlight = {};
+  }
 
   if (query.filters && query.filters.status && query.filters.status[0]) {
     const filter = { term: {} };
@@ -55,6 +60,7 @@ module.exports = client => async (term = '', query = {}) => {
       match: {
         title: {
           query: term,
+          operator: 'and',
           boost: 1.5
         }
       }


### PR DESCRIPTION
There are some issues with CSV downloads of large result sets failing on prod. Also an issue with results with only a single term in the search query in the title being returned.

* add an extended timeout to improve chances of doing CSV export
* remove highlighting if large number of rows requested (i.e. is a CSV download)
* add `AND` operator to title search so all terms in search query must match