### PR TITLE
Retry index deletion if it fails with a snapshot in progress

### DIFF
--- a/lib/indexers/establishments/index.js
+++ b/lib/indexers/establishments/index.js
@@ -1,4 +1,5 @@
-const { pick, get } = require('lodash');
+const { pick } = require('lodash');
+const deleteIndex = require('../utils/delete-index');
 
 const indexName = 'establishments';
 const columnsToIndex = ['id', 'name', 'licenceNumber', 'status', 'keywords'];
@@ -18,13 +19,7 @@ const indexEstablishment = (esClient, establishment) => {
 const reset = esClient => {
   console.log(`Rebuilding index ${indexName}`);
   return Promise.resolve()
-    .then(() => esClient.indices.delete({ index: indexName }))
-    .catch(e => {
-      if (get(e, 'body.error.type') === 'index_not_found_exception') {
-        return;
-      }
-      throw e;
-    })
+    .then(() => deleteIndex(esClient, indexName))
     .then(() => {
       return esClient.indices.create({
         index: indexName,

--- a/lib/indexers/places/index.js
+++ b/lib/indexers/places/index.js
@@ -1,4 +1,5 @@
-const { pick, get } = require('lodash');
+const { pick } = require('lodash');
+const deleteIndex = require('../utils/delete-index');
 
 const indexName = 'places';
 const columnsToIndex = ['id', 'establishmentId', 'suitability', 'holding', 'restrictions'];
@@ -39,13 +40,7 @@ const indexPlace = (esClient, place) => {
 const reset = esClient => {
   console.log(`Rebuilding index ${indexName}`);
   return Promise.resolve()
-    .then(() => esClient.indices.delete({ index: indexName }))
-    .catch(e => {
-      if (get(e, 'body.error.type') === 'index_not_found_exception') {
-        return;
-      }
-      throw e;
-    })
+    .then(() => deleteIndex(esClient, indexName))
     .then(() => {
       return esClient.indices.create({
         index: indexName,

--- a/lib/indexers/profiles/index.js
+++ b/lib/indexers/profiles/index.js
@@ -1,5 +1,6 @@
-const { pick, get } = require('lodash');
+const { pick } = require('lodash');
 const synonyms = require('./synonyms');
+const deleteIndex = require('../utils/delete-index');
 
 const indexName = 'profiles';
 const columnsToIndex = [
@@ -30,13 +31,7 @@ const indexProfile = (esClient, profile) => {
 const reset = esClient => {
   console.log(`Rebuilding index ${indexName}`);
   return Promise.resolve()
-    .then(() => esClient.indices.delete({ index: indexName }))
-    .catch(e => {
-      if (get(e, 'body.error.type') === 'index_not_found_exception') {
-        return;
-      }
-      throw e;
-    })
+    .then(() => deleteIndex(esClient, indexName))
     .then(() => {
       return esClient.indices.create({
         index: indexName,

--- a/lib/indexers/projects-content/index.js
+++ b/lib/indexers/projects-content/index.js
@@ -1,5 +1,6 @@
-const { pick, get } = require('lodash');
+const { pick } = require('lodash');
 const extractContent = require('./extract-content');
+const deleteIndex = require('../utils/delete-index');
 
 const indexName = 'projects-content';
 const columnsToIndex = [
@@ -47,13 +48,7 @@ const indexProject = (esClient, project, ProjectVersion) => {
 const reset = esClient => {
   console.log(`Rebuilding index ${indexName}`);
   return Promise.resolve()
-    .then(() => esClient.indices.delete({ index: indexName }))
-    .catch(e => {
-      if (get(e, 'body.error.type') === 'index_not_found_exception') {
-        return;
-      }
-      throw e;
-    })
+    .then(() => deleteIndex(esClient, indexName))
     .then(() => {
       return esClient.indices.create({
         index: indexName,

--- a/lib/indexers/projects/index.js
+++ b/lib/indexers/projects/index.js
@@ -1,5 +1,6 @@
-const { pick, get } = require('lodash');
+const { pick } = require('lodash');
 const extractSpecies = require('./extract-species');
+const deleteIndex = require('../utils/delete-index');
 
 const indexName = 'projects';
 const columnsToIndex = [
@@ -49,13 +50,7 @@ const indexProject = (esClient, project, ProjectVersion) => {
 const reset = esClient => {
   console.log(`Rebuilding index ${indexName}`);
   return Promise.resolve()
-    .then(() => esClient.indices.delete({ index: indexName }))
-    .catch(e => {
-      if (get(e, 'body.error.type') === 'index_not_found_exception') {
-        return;
-      }
-      throw e;
-    })
+    .then(() => deleteIndex(esClient, indexName))
     .then(() => {
       return esClient.indices.create({
         index: indexName,

--- a/lib/indexers/utils/delete-index.js
+++ b/lib/indexers/utils/delete-index.js
@@ -1,0 +1,18 @@
+const { get } = require('lodash');
+
+const wait = (t = 30000) => new Promise(resolve => setTimeout(resolve, t));
+
+const reset = (client, index, options = {}) => {
+  return Promise.resolve()
+    .then(() => client.indices.delete({ index }))
+    .catch(e => {
+      if (get(e, 'body.error.type') === 'index_not_found_exception') {
+        return;
+      }
+      if (get(e, 'body.error.type') === 'snapshot_in_progress_exception' && !options.retry) {
+        return wait(30000).then(() => reset(client, index, { retry: true }));
+      }
+      throw e;
+    });
+};
+module.exports = reset;


### PR DESCRIPTION
There is no way to switch off snapshot collection, but rebuilding the indexes will occasionally fail because it can't be deleted while a snapshot is in progress.

Instead if that error is thrown in response to a deletion then wait 30 seconds and try again.