### PR TITLE
Include score in response sets

### DIFF
--- a/lib/search/global/router.js
+++ b/lib/search/global/router.js
@@ -36,7 +36,7 @@ module.exports = (settings) => {
     return Promise.resolve()
       .then(() => req.search(term, index, req.query))
       .then(response => {
-        res.response = response.body.hits.hits.map(r => ({ ...omit(r._source, 'content'), highlight: r.highlight }));
+        res.response = response.body.hits.hits.map(r => ({ ...omit(r._source, 'content'), highlight: r.highlight, score: r._score }));
         res.meta = {
           filters: index === 'projects'
             ? combineInactive(response.body.statuses)


### PR DESCRIPTION
This makes it a little easier on the client to debug issues with ordering of search results.