### PR TITLE
Sort advanced project search by title if no search term provided

### DIFF
--- a/lib/search/global/projects-content.js
+++ b/lib/search/global/projects-content.js
@@ -8,7 +8,7 @@ module.exports = client => async (term = '', query = {}) => {
   const params = {
     index,
     timeout: '30s',
-    ...sortParams(query, [])
+    ...sortParams(query, ['title'])
   };
 
   params.body.query = {


### PR DESCRIPTION
Currently the results of the default view of advanced project search are random. This causes a difference in the visual regression every time it runs.

Set the default sort order when no search term is provided to title for consistency with regular project search.