### PR TITLE
Remove whitespace from ngram tokeniser

### DIFF
--- a/lib/indexers/profiles/index.js
+++ b/lib/indexers/profiles/index.js
@@ -78,7 +78,7 @@ const reset = esClient => {
                   type: 'ngram',
                   min_gram: 4,
                   max_gram: 4,
-                  token_chars: ['letter', 'whitespace']
+                  token_chars: ['letter']
                 }
               }
             }


### PR DESCRIPTION
This was causing spaces between names to be included in search matches, and consequently malformed markdown to be generated in highlight matches - e.g. `**jean claude van **damme`

Removing the whitespace from the characters allowed in ngrams prevents this but does not seem to obviously affect the quality of matches.