### PR TITLE
Include id in enforcements index

### DIFF
--- a/lib/indexers/enforcements/index.js
+++ b/lib/indexers/enforcements/index.js
@@ -2,7 +2,7 @@ const { pick } = require('lodash');
 const deleteIndex = require('../utils/delete-index');
 
 const indexName = 'enforcements';
-const columnsToIndex = ['caseNumber', 'createdAt', 'updatedAt'];
+const columnsToIndex = ['id', 'caseNumber', 'createdAt', 'updatedAt'];
 
 const indexEnforcement = (esClient, enforcement) => {
   return esClient.index({


### PR DESCRIPTION
Not having the id breaks the "View case" links in the enforcement list, as well as meaning that incoming requests to update an index always create a new search entry rather than updating existing rows.